### PR TITLE
Fix broken link for "Horovod with oneCCL"

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 oneAPI Collective Communications Library (oneCCL) provides an efficient implementation of communication patterns used in deep learning.
 
 oneCCL is integrated into:
-* [Horovod\*](https://github.com/horovod/horovod) (distributed training framework). Refer to [Horovod with oneCCL](https://github.com/horovod/horovod/blob/master/docs/oneccl.md) for details.
+* [Horovod\*](https://github.com/horovod/horovod) (distributed training framework). Refer to [Horovod with oneCCL](https://github.com/horovod/horovod/blob/master/docs/oneccl.rst) for details.
 * [PyTorch\*](https://github.com/pytorch/pytorch) (machine learning framework). Refer to [PyTorch bindings for oneCCL](https://github.com/intel/torch-ccl) for details.
 
 Release notes available by [link](https://software.intel.com/content/www/us/en/develop/articles/oneapi-collective-communication-library-ccl-release-notes.html).


### PR DESCRIPTION
Update the broken documentation link for "Horovod with oneCCL" in the README.