### PR TITLE
Fixes for using OFI shared memory provider

### DIFF
--- a/src/atl/ofi/atl_ofi.cpp
+++ b/src/atl/ofi/atl_ofi.cpp
@@ -54,6 +54,7 @@ atl_status_t atl_ofi::init(int* argc,
                      ", expected offset ",
                      offsetof(atl_req_t, internal));
 
+    enable_shm = attr->in.enable_shm;
     ret = atl_ofi_set_env(*attr);
     ATL_CHECK_STATUS(ret, "atl_ofi_set_env error");
 

--- a/src/atl/ofi/atl_ofi_helper.hpp
+++ b/src/atl/ofi/atl_ofi_helper.hpp
@@ -113,7 +113,7 @@
                 CCL_THROW("OFI function error"); \
                 break; \
             } \
-            (void)poll(ep); \
+            (void)progress_ep(ep); \
             retry_count++; \
         } while (((ret_val) == -FI_EAGAIN) && (retry_count < max_retry_count)); \
     } while (0)


### PR DESCRIPTION
OneCCL has the capability to use two end points,a shared memory provider endpoint for intra node and a network provider endpoint for internode.

The use of shared memory provider is enabled by environment variable CCL_ATL_SHM. However, two bugs in the code base does not allow the use of OFI shm provider.

1. CCL_ATL_SHM setting is not used during OFI transport initialization and shm provider for intra node communication remains disabled (see  atl_ofi::init)
2. OFI shm provider initiates a connection request on first message/rma while returning retry status. It expects progress before retry to complete connection request. OneCCL retry routine performs poll before retry to progress. However, under certain conditions, the progress type is set as   ATL_PROGRESS_CHECK (see alt_ofi::init). The poll method does not progress when type is CHECK. Hence the shm provider keeps sending retry.

The PR has the fixes for the two bugs.