### PR TITLE
Intel(R) oneAPI Collective Communications Library (oneCCL) 2021.11.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -303,7 +303,7 @@ endif()
 
 set(CCL_MAJOR_VERSION     "2021")
 set(CCL_MINOR_VERSION     "11")
-set(CCL_UPDATE_VERSION    "0")
+set(CCL_UPDATE_VERSION    "2")
 set(CCL_PRODUCT_STATUS    "Gold")
 string(TIMESTAMP CCL_PRODUCT_BUILD_DATE "%Y-%m-%dT %H:%M:%SZ")
 get_vcs_properties("git")

--- a/src/kernels/bf16.h
+++ b/src/kernels/bf16.h
@@ -34,17 +34,17 @@ ushort __fp32_to_bf16(float V) {
 #else // cl_intel_bfloat16_conversions
 
 // declare SPIR-V intrinsics directly
-ushort __builtin_spirv_OpConvertFToBF16INTEL_f32(float);
-float __builtin_spirv_OpConvertBF16ToFINTEL_i16(ushort);
+ushort __builtin_IB_ftobf_1(float);
+float __builtin_IB_bftof_1(ushort);
 
 // implement built-in functions using these intrinsics
 #define __ovld __attribute__((overloadable))
 ushort __ovld intel_convert_bfloat16_as_ushort(float f) {
-    return __builtin_spirv_OpConvertFToBF16INTEL_f32(f);
+    return __builtin_IB_ftobf_1(f);
 }
 
 float __ovld intel_convert_as_bfloat16_float(ushort u) {
-    return __builtin_spirv_OpConvertBF16ToFINTEL_i16(u);
+    return __builtin_IB_bftof_1(u);
 }
 
 #endif // cl_intel_bfloat16_conversions

--- a/third-party-programs.txt
+++ b/third-party-programs.txt
@@ -1,5 +1,5 @@
 Intel(R) oneAPI Collective Communications Library (oneCCL)
-2021.11.1 Third Party Programs File
+2021.11.2 Third Party Programs File
 
 This file is the "third-party-programs.txt" file specified in the associated
 Intel end user license agreement for the Intel software you are licensing.


### PR DESCRIPTION
This PR aligns the contents of the repository with the Intel(R) oneAPI Collective Communications Library 2021.11.2 release.